### PR TITLE
add slightly better compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ src/taming-transformers
 /ray
 /tmp
 /hordelib
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/worker/jobs/interrogation.py
+++ b/worker/jobs/interrogation.py
@@ -122,7 +122,7 @@ class InterrogationHordeJob(HordeJobFramework):
             logger.debug(self.r2_upload)
             buffer = BytesIO()
             # We send as WebP to avoid using all the horde bandwidth
-            self.image.save(buffer, format="WebP", quality=95)
+            self.image.save(buffer, format="WebP", quality=95, method=6)
             if self.r2_upload:
                 put_response = requests.put(self.r2_upload, data=buffer.getvalue())
                 logger.debug("R2 Upload response: {}", put_response)

--- a/worker/jobs/stable_diffusion.py
+++ b/worker/jobs/stable_diffusion.py
@@ -292,7 +292,7 @@ class StableDiffusionHordeJob(HordeJobFramework):
         # images, seed, info, stats = txt2img(**self.current_payload)
         buffer = BytesIO()
         # We send as WebP to avoid using all the horde bandwidth
-        self.image.save(buffer, format="WebP", quality=self.upload_quality)
+        self.image.save(buffer, format="WebP", quality=self.upload_quality, method=6)
         if self.r2_upload:
             put_response = requests.put(self.r2_upload, data=buffer.getvalue())
             generation = "R2"


### PR DESCRIPTION
I usually use `-m6` to get a slightly more reduced filesize. This isn't a quality trade-off, it's an encoding time trade-off[^2]

[^2]: iirc from my testing a couple years ago, the extra time it takes on my 10yo PC is only noticeable with animations and mass-conversions, occasionally with big photos. ~~also 🖕 ty 🖕 Google 🖕 for making such a small limit on image dimensions, i wanted to convert my webtoon collection to webp, but the images are too tall🖕🖕🖕🖕🖕...what are you gonna do when we get 100mp cameras? oh, wait, we already have those...~~

I *think* autofilter (for the deblocking filter, iirc) would also provide better results[^1], but pillow doesn't support that option, and same with sharp_yuv.

I actually started looking at this stuff because of crap image quality I was seeing, but now i think it might actually be discord that's causing image quality issues, not horde.

[^1]: [see `-af`](https://developers.google.com/speed/webp/docs/cwebp#lossy_options)