### PR TITLE
feat: hordelib to at least v1.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cu118
 torch # We have to place it here otherwise it installs the CPU version
-hordelib==1.3.17
+horde_model_reference~=0.1.1
+hordelib>=1.5.1
 gradio
 pyyaml
 unidecode


### PR DESCRIPTION
- Includes the clipfree workaround
- Pins horde_model_reference to minor version in anticipation of upcoming breaking changes.