### PR TITLE
fix: don't hard fail if some non-exception failure happens in `download_image_data`

### DIFF
--- a/worker/jobs/poppers.py
+++ b/worker/jobs/poppers.py
@@ -87,6 +87,7 @@ class JobPopper:
 
     def download_image_data(self, image_url):
         """Returns the image data, not a PIL"""
+        img_data = None
         try:
             with requests.get(image_url, stream=True, timeout=2) as r:
                 size = r.headers.get("Content-Length", 0)
@@ -107,6 +108,8 @@ class JobPopper:
         except Exception as err:
             logger.error(err)
             return None
+        if not img_data:
+            logger.error(f"Could not download source image from R2 {image_url}. Skipping source image.")
         return img_data
 
     def convert_image_data_to_pil(self, img_data):


### PR DESCRIPTION
If the relevant function fails in without an exception, `img_data` is addressed before being assigned. This PR creates a fallback position (defines it as `None` to start). 