### PR TITLE
fix: future support for image_is_control for controlnet

### DIFF
--- a/worker/jobs/kudos.py
+++ b/worker/jobs/kudos.py
@@ -131,9 +131,7 @@ class KudosModel:
         kudos = kudos * basis_scale
 
         # Scale our kudos by the time the job will take to complete
-        kudos = job_ratio * kudos
-
-        return kudos
+        return job_ratio * kudos
 
     @classmethod
     def one_hot_encode(cls, strings, unique_strings):

--- a/worker/jobs/stable_diffusion.py
+++ b/worker/jobs/stable_diffusion.py
@@ -121,7 +121,7 @@ class StableDiffusionHordeJob(HordeJobFramework):
                 and "stable diffusion 2" not in model_baseline
             ):
                 gen_payload["control_type"] = self.current_payload["control_type"]
-                gen_payload["init_as_control"] = self.current_payload["image_is_control"]
+                gen_payload["image_is_control"] = self.current_payload["image_is_control"]
                 gen_payload["return_control_map"] = self.current_payload.get("return_control_map", False)
             if "loras" in self.current_payload:
                 gen_payload["loras"] = self.current_payload["loras"]

--- a/worker/post_process.py
+++ b/worker/post_process.py
@@ -43,7 +43,7 @@ def strip_background(payload):
         alpha_matting_erode_size=10,
     )
     del session
-    return image  # noqa: RET504
+    return image
 
 
 # At the bottom, as we need to define the method first

--- a/worker/ui.py
+++ b/worker/ui.py
@@ -743,9 +743,8 @@ class TerminalUI:
             ref_path = os.path.join(".git", *head_contents[5:].split("/"))
 
             with open(ref_path, "r") as f:
-                commit_hash = f.read().strip()
+                return f.read().strip()
 
-            return commit_hash
         except Exception:
             return ""
 
@@ -801,8 +800,7 @@ class TerminalUI:
 
     def get_hordelib_version(self):
         try:
-            package_version = pkg_resources.get_distribution("hordelib").version
-            return package_version
+            return pkg_resources.get_distribution("hordelib").version
         except pkg_resources.DistributionNotFound:
             return "Unknown"
 


### PR DESCRIPTION
Some legacy behavior remapped `image_is_control` when submitting a generation payload to hordelib. This changes this behavior to match what hordelib now expects (which is what AI-Horde is returning anyway).

This is in anticipation of the hordelib patch which will enable this feature. For now, it should not cause any incompatibility as hordelib was already tolerating this being sent without specific support on its side.