### PR TITLE
chore: temp pin hordelib (to 1.5.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 torch # We have to place it here otherwise it installs the CPU version
 horde_model_reference~=0.1.1
 horde_clipfree == 0.0.1
-hordelib>=1.5.1
+hordelib~=1.5.1
 gradio
 pyyaml
 unidecode


### PR DESCRIPTION
To support the upcoming https://github.com/jug-dev/hordelib/pull/20 release having a beta window. 