### PR TITLE
fix: stop worker on continued OutOfMemoryError exceptions

### DIFF
--- a/worker/enums.py
+++ b/worker/enums.py
@@ -5,6 +5,7 @@ from enum import IntEnum
 class JobStatus(IntEnum):
     """Job status enum"""
 
+    OUT_OF_MEMORY = -2
     FAULTED = -1
     INIT = 0
     POLLING = 1

--- a/worker/jobs/framework.py
+++ b/worker/jobs/framework.py
@@ -54,7 +54,11 @@ class HordeJobFramework:
 
     def is_faulted(self):
         """Check if the job is faulted"""
-        return self.status in [JobStatus.FAULTED, JobStatus.FINALIZING_FAULTED]
+        return self.status in [JobStatus.FAULTED, JobStatus.FINALIZING_FAULTED, JobStatus.OUT_OF_MEMORY]
+
+    def is_out_of_memory(self):
+        """Check if the job ran out of memory"""
+        return self.status in [JobStatus.OUT_OF_MEMORY]
 
     @logger.catch(reraise=True)
     def start_job(self):
@@ -89,7 +93,7 @@ class HordeJobFramework:
         """Submits the job to the server to earn our kudos.
         This method MUST be extended with the specific logic for this worker
         At the end it MUST set the job state to DONE"""
-        if self.status == JobStatus.FAULTED:
+        if self.status == JobStatus.FAULTED or self.status == JobStatus.OUT_OF_MEMORY:
             self.submit_dict = {
                 "id": self.current_id,
                 "state": "faulted",

--- a/worker/workers/framework.py
+++ b/worker/workers/framework.py
@@ -156,7 +156,7 @@ class WorkerFramework:
                 if job.is_out_of_memory():
                     logger.error("Job failed with out of memory error")
                     self.out_of_memory_jobs += 1
-                if self.out_of_memory_jobs >= 5:
+                if self.out_of_memory_jobs >= 10:
                     logger.critical("Too many jobs have failed with out of memory error. Aborting!")
                     self.should_stop = True
                     return

--- a/worker/workers/framework.py
+++ b/worker/workers/framework.py
@@ -20,6 +20,7 @@ class WorkerFramework:
         self.should_restart = False
         self.consecutive_executor_restarts = 0
         self.consecutive_failed_jobs = 0
+        self.out_of_memory_jobs = 0
         self.executor = None
         self.ui = None
         self.last_stats_time = time.time()
@@ -152,6 +153,13 @@ class WorkerFramework:
                 if job_thread.exception(timeout=1):
                     logger.error("Job failed with exception, {}", job_thread.exception())
                     logger.exception(job_thread.exception())
+                if job.is_out_of_memory():
+                    logger.error("Job failed with out of memory error")
+                    self.out_of_memory_jobs += 1
+                if self.out_of_memory_jobs >= 5:
+                    logger.critical("Too many jobs have failed with out of memory error. Aborting!")
+                    self.should_stop = True
+                    return
                 if self.consecutive_executor_restarts > 0:
                     logger.critical(
                         "Worker keeps crashing after thread executor restart. " "Cannot be salvaged. Aborting!",


### PR DESCRIPTION
In my experience so far, this tends to cascade, possibly due to memory leaking once the first one occurs. Further, the worst-case jobs that may precipitate this tend to happen in clusters, causing the worker to fail repeatedly.

As of this change, if more than 10 OutOfMemoryErrors occur, the worker will halt to mitigate the issue. It is not unheard of for a few OutOfMemoryErrors, but at the point of 10 (and therefore 10 failed jobs), the worker needs to be looked at as it isn't going to fix itself at this point in time.