### PR TITLE
fix: disable `dynamic_models` if `number_of_dynamic_models` not set/is 0

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -298,7 +298,7 @@ class WebUI:
         config = self.reload_config()
 
         # Merge values which require some pre-processing
-        skipped_keys = ["models_on_disk"]
+        skipped_keys = ["models_on_disk", "special_models_to_load", "special_top_models_to_load"]
         models_to_load = []
         for key, value in args.items():
             cfgkey = self._cfg(key.label)

--- a/worker/bridge_data/stable_diffusion.py
+++ b/worker/bridge_data/stable_diffusion.py
@@ -105,7 +105,7 @@ class StableDiffusionBridgeData(BridgeDataTemplate):
             logger.warning(
                 f"Dynamic models is configured to load {self.number_of_dynamic_models} models, but "
                 f"{top_n if top_n else 'All Models'} models "
-                f"are manually configured to be loaded. Disabling dynamic models."
+                f"are manually configured to be loaded. Disabling dynamic models.",
             )
 
             logger.warning(
@@ -115,7 +115,6 @@ class StableDiffusionBridgeData(BridgeDataTemplate):
             )
             self.dynamic_models = False
             self.number_of_dynamic_models = 0
-
 
         if not self.dynamic_models:
             self.model_names = self.models_to_load

--- a/worker/bridge_data/stable_diffusion.py
+++ b/worker/bridge_data/stable_diffusion.py
@@ -92,6 +92,13 @@ class StableDiffusionBridgeData(BridgeDataTemplate):
         if top_n:
             self.models_to_load.extend(self.get_top_n_models(top_n))
 
+        if self.dynamic_models and not self.number_of_dynamic_models:
+            logger.warning(
+                "Dynamic models are enabled but config option `number_of_dynamic_models` isn't set or is 0. "
+                "Disabling dynamic models.",
+            )
+            self.dynamic_models = False
+
         if not self.dynamic_models:
             self.model_names = self.models_to_load
         else:
@@ -141,7 +148,7 @@ class StableDiffusionBridgeData(BridgeDataTemplate):
         UserSettings.disable_disk_cache.active = self.disable_disk_cache
 
     def check_extra_conditions_for_download_choice(self):
-        return self.dynamic_models or self.always_download
+        return (self.dynamic_models and self.number_of_dynamic_models) or self.always_download
 
     def _is_valid_stable_diffusion_model(self, model_name):
         if model_name in ["safety_checker", "LDSR"]:


### PR DESCRIPTION
This would have prevented the confusion of at least one worker, based on their report the previous behavior caused their intended desire to have `All models` loaded (in the usual way) not work as expected because `dynamic_models` was true, and `number_of_dynamic_models` was 0. 

The deeper problem at hand may need further addressing, but for now, as of this changeset:

- If `dynamic_models` is `True`, but `number_of_dynamic_models` is not set or `0`, the worker will give a warning and disable dynamic models.
- If `dynamic_models` is `True`, but there are more `models_to_load` than `number_of_dynamic_models`, the worker will give a warning and disable dynamic models.

Also, incidentally, I only just noticed a bug I had introduced a while back with webui. See 5836acd5db4e90b794204345670df22aa1aea505 for more info.
