### PR TITLE
fix: alchemy not working if models corrupt/missing

### DIFF
--- a/bridge_alchemy.py
+++ b/bridge_alchemy.py
@@ -2,6 +2,9 @@
 # isort: off
 # We need to import the argparser first, as it sets the necessary Switches
 from worker.argparser.stable_diffusion import args
+from worker.utils.set_envs import set_aiworker_cache_home_from_config
+
+set_aiworker_cache_home_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
 import hordelib
 
 # We need to remove these, to avoid comfyUI trying to use them

--- a/bridge_alchemy.py
+++ b/bridge_alchemy.py
@@ -10,6 +10,7 @@ import hordelib
 # We need to remove these, to avoid comfyUI trying to use them
 hordelib.initialise()
 from hordelib.horde import SharedModelManager
+from hordelib.shared_model_manager import MODEL_CATEGORY_NAMES
 
 # isort: on
 
@@ -23,14 +24,15 @@ if __name__ == "__main__":
 
     bridge_data = InterrogationBridgeData()
     bridge_data.reload_data()
-    SharedModelManager.loadModelManagers(
-        blip=True,
-        clip=True,
-        safety_checker=True,
-        esrgan=True,
-        gfpgan=True,
-        codeformer=True,
-        controlnet=True,
+    SharedModelManager.load_model_managers(
+        [
+            MODEL_CATEGORY_NAMES.safety_checker,
+            MODEL_CATEGORY_NAMES.clip,
+            MODEL_CATEGORY_NAMES.blip,
+            MODEL_CATEGORY_NAMES.codeformer,
+            MODEL_CATEGORY_NAMES.esrgan,
+            MODEL_CATEGORY_NAMES.gfpgan,
+        ],
     )
     try:
         worker = InterrogationWorker(SharedModelManager.manager, bridge_data)

--- a/bridge_scribe.py
+++ b/bridge_scribe.py
@@ -2,12 +2,14 @@
 # isort: off
 # We need to import the argparser first, as it sets the necessary Switches
 from worker.argparser.scribe import args
+from worker.utils.set_envs import set_aiworker_cache_home_from_config
 
+set_aiworker_cache_home_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
+
+from worker.bridge_data.scribe import KoboldAIBridgeData  # noqa: E402
+from worker.logger import logger, quiesce_logger, set_logger_verbosity  # noqa: E402
+from worker.workers.scribe import ScribeWorker  # noqa: E402
 # isort: on
-
-from worker.bridge_data.scribe import KoboldAIBridgeData
-from worker.logger import logger, quiesce_logger, set_logger_verbosity
-from worker.workers.scribe import ScribeWorker
 
 
 def main():

--- a/bridge_scribe.py
+++ b/bridge_scribe.py
@@ -9,6 +9,7 @@ set_aiworker_cache_home_from_config()  # Get `cache_home` from `bridgeconfig.yam
 from worker.bridge_data.scribe import KoboldAIBridgeData  # noqa: E402
 from worker.logger import logger, quiesce_logger, set_logger_verbosity  # noqa: E402
 from worker.workers.scribe import ScribeWorker  # noqa: E402
+
 # isort: on
 
 

--- a/bridge_stable_diffusion.py
+++ b/bridge_stable_diffusion.py
@@ -6,7 +6,7 @@ import os
 from worker.argparser.stable_diffusion import args
 from worker.utils.set_envs import set_aiworker_cache_home_from_config
 
-set_aiworker_cache_home_from_config()  # Get `cache_home` from `bridge_config.yaml` into the environment variable
+set_aiworker_cache_home_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
 
 import hordelib
 

--- a/worker/bridge_data/interrogation.py
+++ b/worker/bridge_data/interrogation.py
@@ -49,6 +49,7 @@ class InterrogationBridgeData(BridgeDataTemplate):
                 ),
                 status="Joining Horde",
             )
+
     def check_extra_conditions_for_download_choice(self):
         """Extend if any condition on the specifics for this bridge_data will force a 'y' result"""
         return True

--- a/worker/bridge_data/interrogation.py
+++ b/worker/bridge_data/interrogation.py
@@ -49,3 +49,6 @@ class InterrogationBridgeData(BridgeDataTemplate):
                 ),
                 status="Joining Horde",
             )
+    def check_extra_conditions_for_download_choice(self):
+        """Extend if any condition on the specifics for this bridge_data will force a 'y' result"""
+        return True


### PR DESCRIPTION
- [fix: do not prompt to dl alchemy models](https://github.com/Haidra-Org/AI-Horde-Worker/commit/00615d3e67d5d77f401adc71754ff3ad5b2cad43)
  - I am making the executive decision to just default to downloading with no prompt the PP/clip/blip models if its just the alchemy worker running.
- [fix: have all worker types import AIWORKER_CACHE_HOME early](https://github.com/Haidra-Org/AI-Horde-Worker/commit/9f8af058ac07c32c983c093797c16ed1e1b73fb9)
  - One day, in the far flung future, a proper worker refactor would eliminate the need for the *very* sensitive import orders we see.
- [fix: use updated load_model_managers method](https://github.com/Haidra-Org/AI-Horde-Worker/commit/769ab04db0e67d841f592ca4abee6ed951cb051d)
 