### PR TITLE
fix: VRAM mismanagement band-aid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ clip-anytorch
 diffusers
 omegaconf
 setuptools
+typing_extensions


### PR DESCRIPTION
See #268 for some background.

This change will:
- Instigate a worker 'soft restart', forcibly unloading all compvis models in certain situations:
  - If a job is stale
  - If an impossible number of models are reported as being in VRAM
- If more than 15 soft restarts occur, the worker is halted.
- Tracks `consecutive_failed_jobs` across soft restarts.