### PR TITLE
feat: run pilot job on start, notify when jobs seem slower than would be expected

### DIFF
--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -142,6 +142,10 @@ models_to_skip:
   #- "Zeipher Female Model"
   #- "Hentai Diffusion"
 
+# If you are getting messages about jobs taking too long, you can change this to true if you no longer want to see them
+# Please note, that if you *are* getting these messages, you are serving jobs substantially slower than is ideal,
+# and you very likely would get more kudos/hr if you just lower your max_power.
+suppress_speed_warnings: false
 
 ## Scribe (LLM Worker)
 

--- a/worker/bridge_data/framework.py
+++ b/worker/bridge_data/framework.py
@@ -48,6 +48,7 @@ class BridgeDataTemplate:
         self.username = None
         self.models_reloading = False
         self.max_models_to_download = 10
+        self.suppress_speed_warnings = False
 
     def load_config(self):
         # YAML config

--- a/worker/bridge_data/stable_diffusion.py
+++ b/worker/bridge_data/stable_diffusion.py
@@ -149,7 +149,7 @@ class StableDiffusionBridgeData(BridgeDataTemplate):
         self.model_names.insert(0, "safety_checker")
         self.model_names.insert(0, "ViT-L/14")
         if self.allow_post_processing:
-            self.model_names += list(POST_PROCESSORS_HORDELIB_MODELS)
+            self.model_names = list(POST_PROCESSORS_HORDELIB_MODELS) + self.model_names
         if (not self.initialized and not self.models_reloading) or previous_url != self.horde_url:
             logger.init(
                 (

--- a/worker/jobs/framework.py
+++ b/worker/jobs/framework.py
@@ -163,7 +163,7 @@ class HordeJobFramework:
                     if time_spent_processing > (reward * 3) and not self.bridge_data.suppress_speed_warnings:
                         logger.warning(
                             "This job took longer than average to process."
-                            " Please consider adjusting lowering your max_power.",
+                            " Please consider lowering your max_power.",
                         )
 
                 logger.info(

--- a/worker/jobs/framework.py
+++ b/worker/jobs/framework.py
@@ -156,13 +156,22 @@ class HordeJobFramework:
                     time.sleep(2)
                     continue
                 reward = submit_req.json()["reward"]
+                time_spent_processing = round(time.time() - self.process_time, 1)
+
                 with contextlib.suppress(ValueError):
-                    reward = f"{float(reward):.1f}"
+                    reward = float(reward)
+                    if time_spent_processing > (reward * 3) and not self.bridge_data.suppress_speed_warnings:
+                        logger.warning(
+                            "This job took longer than average to process."
+                            " Please consider adjusting lowering your max_power.",
+                        )
+
                 logger.info(
-                    f"Submitted job with id {self.current_id} and contributed for {reward}. "
+                    f"Submitted job with id {self.current_id} and contributed for {reward:.1f}. "
                     f"Job took {round(time.time() - self.start_time,1)} seconds since queued "
-                    f"and {round(time.time() - self.process_time,1)} since start.",
+                    f"and {time_spent_processing} since start.",
                 )
+
                 self.post_submit_tasks(submit_req)
                 if self.status == JobStatus.FINALIZING_FAULTED:
                     self.status = JobStatus.FAULTED

--- a/worker/workers/framework.py
+++ b/worker/workers/framework.py
@@ -15,6 +15,7 @@ class WorkerFramework:
         self.running_jobs = []
         self.waiting_jobs = []
         self.run_count = 0
+        self.pilot_job_was_run = False
         self.last_config_reload = 0
         self.should_stop = False
         self.should_restart = False

--- a/worker/workers/stable_diffusion.py
+++ b/worker/workers/stable_diffusion.py
@@ -214,6 +214,15 @@ class StableDiffusionWorker(WorkerFramework):
         stale_time = time.time() + (job_base.get("ddim_steps", 50) * 5) + 10
 
         resulting_image = hordelib.basic_inference(job_base)
+        shared_error_messages = [
+            ("It is very likely the worker is not configured correctly for this system."),
+            ("Consider lowering your `max_power` in your bridgeData."),
+            (
+                f"With `max_power` set to {self.bridge_data.max_power}, "
+                f"the max resolution this worker would process is {test_resolution}x{test_resolution}."
+            ),
+            ("You can also ask the developers in the official discord for help."),
+        ]
         if not resulting_image or time.time() > stale_time:
             if not resulting_image:
                 logger.error("Failed to run a basic inference job. This is a critical error.")
@@ -224,15 +233,8 @@ class StableDiffusionWorker(WorkerFramework):
                         "This job would have been rejected by the horde."
                     ),
                 )
-            logger.error("Tt is very likely the worker is not configured correctly for this system.")
-            logger.error("Consider lowering your `max_power` in your bridgeData.")
-            logger.error(
-                (
-                    f"With `max_power` set to {self.bridge_data.max_power}, "
-                    f"the max resolution this worker would process is {test_resolution}x{test_resolution}."
-                ),
-            )
-            logger.error("You can also ask the developers in the official discord for help.")
+            for error_message in shared_error_messages:
+                logger.error(error_message)
             exit(1)
 
         logger.info("Basic inference job completed successfully.")
@@ -245,6 +247,7 @@ class StableDiffusionWorker(WorkerFramework):
             upscale_check = hordelib.image_upscale(pp_payload)
             if not upscale_check:
                 logger.error("Failed to run a basic upscale job. This is a critical error.")
-                logger.error("And is it is very likely the worker is not configured correctly for this system.")
+                for error_message in shared_error_messages:
+                    logger.error(error_message)
                 exit(1)
             logger.info("Basic upscale job completed successfully.")

--- a/worker/workers/stable_diffusion.py
+++ b/worker/workers/stable_diffusion.py
@@ -183,6 +183,7 @@ class StableDiffusionWorker(WorkerFramework):
                 logger.warning("There are still models loaded on the GPU. You will probably have memory issues.")
                 logger.warning(f"Models on GPU: {models_on_gpu}")
                 logger.warning(f"Free VRAM: {get_torch_free_vram_mb()}MB")
+            self.model_manager.compvis.load_disk_cached_models()
         self.reload_data()
 
     def run_pilot_job(self):

--- a/worker/workers/stable_diffusion.py
+++ b/worker/workers/stable_diffusion.py
@@ -211,8 +211,8 @@ class StableDiffusionWorker(WorkerFramework):
         hordelib = HordeLib()
         logger.info(f"Running a basic inference job of {test_resolution}x{test_resolution} to test the worker...")
 
-        # stale_time = time.time() + (job_base.get("ddim_steps", 50) * 5) + 10
-        stale_time = time.time() + 1
+        stale_time = time.time() + (job_base.get("ddim_steps", 50) * 5) + 10
+
         resulting_image = hordelib.basic_inference(job_base)
         if not resulting_image or time.time() > stale_time:
             if not resulting_image:

--- a/worker/workers/stable_diffusion.py
+++ b/worker/workers/stable_diffusion.py
@@ -30,7 +30,14 @@ class StableDiffusionWorker(WorkerFramework):
         can_do = loaded_models > 0
         if not can_do:
             logger.info("No models loaded. Waiting for the first model to be up before polling the horde")
-        elif self.run_count == 0:
+        elif self.run_count == 0 and not self.pilot_job_was_run:
+            if (
+                self.bridge_data.allow_post_processing
+                and "RealESRGAN_x4plus" not in self.model_manager.esrgan.get_loaded_models_names()
+            ):
+                return False
+
+            self.pilot_job_was_run = True
             self.run_pilot_job()
         return can_do
 

--- a/worker/workers/stable_diffusion.py
+++ b/worker/workers/stable_diffusion.py
@@ -39,7 +39,7 @@ class StableDiffusionWorker(WorkerFramework):
 
             self.pilot_job_was_run = True
             self.run_pilot_job()
-        return can_do
+        return can_do and self.pilot_job_was_run
 
     # We want this to be extendable as well
     def add_job_to_queue(self):

--- a/worker/workers/stable_diffusion.py
+++ b/worker/workers/stable_diffusion.py
@@ -30,7 +30,7 @@ class StableDiffusionWorker(WorkerFramework):
         can_do = loaded_models > 0
         if not can_do:
             logger.info("No models loaded. Waiting for the first model to be up before polling the horde")
-        if self.run_count == 0:
+        elif self.run_count == 0:
             self.run_pilot_job()
         return can_do
 


### PR DESCRIPTION
New as of this PR:

- On worker start, a single job ('pilot job') of the max configured resolution will run. (IE, 1024x1024 for max_power 32).
  - If post processing is enabled, it also attempts to do a 4x upscale.
  - If either of these fail, the worker will exit with an error message to this effect.
- If a job takes 3x or longer than the kudos reward in seconds, the worker will now warn that the jobs in question are probably slower than the worker operator intends.
  - If they *do* intend this, they can silence the messages with the `suppress_speed_warnings` setting in bridgeData.

Fixes:
- Webui now properly reports three configurations of model folders in `AIWORKER_CACHE_HOME` which hordelib otherwise supports
- The soft restart procedure now correctly loads all the models available in disk cache, instead of attempting to rebuild the cache files.
- The post processors models are loaded before inference models if they are enabled
