### PR TITLE
fix: attempts to address new issues with install

### DIFF
--- a/fix-corrupt-packages.sh
+++ b/fix-corrupt-packages.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-bin/micromamba clean -a -y

--- a/fix-corrupt-packages.sh
+++ b/fix-corrupt-packages.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bin/micromamba clean -a -y

--- a/horde-bridge.sh
+++ b/horde-bridge.sh
@@ -1,11 +1,2 @@
 #!/bin/sh
-# Get the directory of the current script
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-# Build the absolute path to the Conda environment
-CONDA_ENV_PATH="$SCRIPT_DIR/conda/envs/linux/lib"
-
-# Add the Conda environment to LD_LIBRARY_PATH
-export LD_LIBRARY_PATH="$CONDA_ENV_PATH:$LD_LIBRARY_PATH"
-
 ./runtime.sh python -s bridge_stable_diffusion.py $*

--- a/runtime.cmd
+++ b/runtime.cmd
@@ -5,6 +5,13 @@ cd /d "%~dp0"
 SET CONDA_SHLVL=
 SET PYTHONNOUSERSITE=1
 SET PYTHONPATH=
+SET MAMBA_ROOT_PREFIX=%~dp0conda
+
+echo %MAMBA_ROOT_PREFIX%
+
+umamba.exe shell hook -s cmd.exe -p %MAMBA_ROOT_PREFIX% -v
+call %MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat
+
 
 Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
 IF EXIST CONDA GOTO APP
@@ -13,6 +20,7 @@ IF EXIST CONDA GOTO APP
 call update-runtime
 
 :APP
-call conda\condabin\activate.bat windows
+call %MAMBA_ROOT_PREFIX%\condabin\micromamba.bat activate windows
+
 %*
 IF [%1] == [] TITLE Runtime Command Prompt && cmd /k

--- a/runtime.sh
+++ b/runtime.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+# Get the directory of the current script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Build the absolute path to the Conda environment
+CONDA_ENV_PATH="$SCRIPT_DIR/conda/envs/linux/lib"
+
+# Add the Conda environment to LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="$CONDA_ENV_PATH:$LD_LIBRARY_PATH"
+export MAMBA_ROOT_PREFIX="$SCRIPT_DIR/conda"
+
 if [ ! -f "conda/envs/linux/bin/python" ]; then
 ./update-runtime.sh
 fi

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -2,6 +2,9 @@
 
 ignore_hordelib=false
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export MAMBA_ROOT_PREFIX="$SCRIPT_DIR/conda"
+
 # Parse command line arguments
 while [[ $# -gt 0 ]]
 do


### PR DESCRIPTION
Unexpected issues around mamba not being able to init the shell have arose. This attempts to address the problem.

Micromamba was unable to actually 'enter' the virtual environment. The error was generally buried in most user outputs and was easy to miss. It probably failed in a more complex way on machines which already had a python install in their PATH. 

This issue was likely limited to windows, but I remain uncertain.

Additionally, this updates the micromamba version used to the latest version.