### PR TITLE
fix: attempts to address new issues with install

### DIFF
--- a/runtime.cmd
+++ b/runtime.cmd
@@ -5,6 +5,13 @@ cd /d "%~dp0"
 SET CONDA_SHLVL=
 SET PYTHONNOUSERSITE=1
 SET PYTHONPATH=
+SET MAMBA_ROOT_PREFIX=%~dp0conda
+
+echo %MAMBA_ROOT_PREFIX%
+
+umamba.exe shell hook -s cmd.exe -p %MAMBA_ROOT_PREFIX% -v
+call %MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat
+
 
 Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
 IF EXIST CONDA GOTO APP
@@ -13,6 +20,7 @@ IF EXIST CONDA GOTO APP
 call update-runtime
 
 :APP
-call conda\condabin\activate.bat windows
+call %MAMBA_ROOT_PREFIX%\condabin\micromamba.bat activate windows
+
 %*
 IF [%1] == [] TITLE Runtime Command Prompt && cmd /k


### PR DESCRIPTION
Unexpected issues around mamba not being able to init the shell have arose. This attempts to address the problem.

Micromamba was unable to actually 'enter' the virtual environment. The error was generally buried in most user outputs and was easy to miss. It probably failed in a more complex way on machines which already had a python install in their PATH.

This issue is likely limited to windows, but I remain uncertain.

Additionally, this updates the micromamba version used to the latest version for windows, which was already the case on linux.