### PR TITLE
fix: loras no longer delete down to 10gig on startup

### DIFF
--- a/bridge_alchemy.py
+++ b/bridge_alchemy.py
@@ -2,9 +2,9 @@
 # isort: off
 # We need to import the argparser first, as it sets the necessary Switches
 from worker.argparser.stable_diffusion import args
-from worker.utils.set_envs import set_aiworker_cache_home_from_config
+from worker.utils.set_envs import set_worker_env_vars_from_config
 
-set_aiworker_cache_home_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
+set_worker_env_vars_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
 import hordelib
 
 # We need to remove these, to avoid comfyUI trying to use them

--- a/bridge_scribe.py
+++ b/bridge_scribe.py
@@ -2,9 +2,9 @@
 # isort: off
 # We need to import the argparser first, as it sets the necessary Switches
 from worker.argparser.scribe import args
-from worker.utils.set_envs import set_aiworker_cache_home_from_config
+from worker.utils.set_envs import set_worker_env_vars_from_config
 
-set_aiworker_cache_home_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
+set_worker_env_vars_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
 
 from worker.bridge_data.scribe import KoboldAIBridgeData  # noqa: E402
 from worker.logger import logger, quiesce_logger, set_logger_verbosity  # noqa: E402

--- a/bridge_stable_diffusion.py
+++ b/bridge_stable_diffusion.py
@@ -4,9 +4,9 @@ import os
 # isort: off
 # We need to import the argparser first, as it sets the necessry Switches
 from worker.argparser.stable_diffusion import args
-from worker.utils.set_envs import set_aiworker_cache_home_from_config
+from worker.utils.set_envs import set_worker_env_vars_from_config
 
-set_aiworker_cache_home_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
+set_worker_env_vars_from_config()  # Get `cache_home` from `bridgeconfig.yaml` into the environment variable
 
 import hordelib
 

--- a/worker/utils/set_envs.py
+++ b/worker/utils/set_envs.py
@@ -6,12 +6,14 @@ import yaml
 from worker.consts import BRIDGE_CONFIG_FILE
 
 
-def set_aiworker_cache_home_from_config():
+def set_worker_env_vars_from_config():
     config_file_as_path = Path(BRIDGE_CONFIG_FILE)
     if config_file_as_path.exists():
         with open(config_file_as_path, "rt", encoding="utf-8", errors="ignore") as configfile:
             config = yaml.safe_load(configfile)
             if "cache_home" in config:
                 os.environ["AIWORKER_CACHE_HOME"] = config["cache_home"]
+            if "max_lora_cache_size" in config:
+                os.environ["HORDE_MAX_LORA_CACHE"] = str(config["max_lora_cache_size"])
         return True
     return False


### PR DESCRIPTION
Relying on the env var `HORDE_MAX_LORA_CACHE` for the default was leading to the purge procedure taking effect on start up.