### PR TITLE
fix: prevent downstream dep issues with pydantic 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu118
 torch # We have to place it here otherwise it installs the CPU version
+pydantic==1.10.12
 horde_model_reference~=0.2.2
 hordelib~=1.6.1
 gradio


### PR DESCRIPTION
Of note, gradio/fastapi (part of webui) was borked when resolving to pydantic 2.0+