### PR TITLE
fix: exit on legacy lora move

### DIFF
--- a/bridge_stable_diffusion.py
+++ b/bridge_stable_diffusion.py
@@ -64,6 +64,7 @@ def check_for_old_dir():
                     os.environ["AIWORKER_CACHE_HOME"] + "/horde_model_reference/legacy/lora.json",
                 )
                 print("lora.json file has been moved to the correct location.")
+                exit()
 
 
 def main():


### PR DESCRIPTION
This will prevent any unforeseen/undefined interactions.