### PR TITLE
fix: undo lora cache preserve fix attempt

### DIFF
--- a/bridge_stable_diffusion.py
+++ b/bridge_stable_diffusion.py
@@ -45,26 +45,6 @@ def check_for_old_dir():
         else:
             print("Existing custom models left in their previous location.")
 
-    possible_lora_paths = [
-        "conda/envs/windows/Lib/site-packages/hordelib/model_database/lora.json",
-        "conda/envs/linux/Lib/site-packages/hordelib/model_database/lora.json",
-    ]
-    for path in possible_lora_paths:
-        if os.path.exists(path):
-            print("Old lora.json file exists.")
-            print(
-                f"Correct location is: {os.environ['AIWORKER_CACHE_HOME']}/horde_model_reference/legacy/lora.json",
-            )
-            answer = input("Do you want to move it to the correct location [Y/N]? ")
-            if answer.lower() == "y":
-                import shutil
-
-                shutil.move(
-                    path,
-                    os.environ["AIWORKER_CACHE_HOME"] + "/horde_model_reference/legacy/lora.json",
-                )
-                print("lora.json file has been moved to the correct location.")
-                exit()
 
 
 def main():

--- a/bridge_stable_diffusion.py
+++ b/bridge_stable_diffusion.py
@@ -46,7 +46,6 @@ def check_for_old_dir():
             print("Existing custom models left in their previous location.")
 
 
-
 def main():
     set_logger_verbosity(args.verbosity)
     quiesce_logger(args.quiet)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 torch # We have to place it here otherwise it installs the CPU version
 pydantic==1.10.12
 horde_model_reference~=0.2.2
-hordelib~=1.6.4
+hordelib==1.6.2
 gradio
 pyyaml
 unidecode


### PR DESCRIPTION
No action needed unless you updated as of today; most workers can ignore the set of updates today.