### PR TITLE
Don't use faulty vram measurement for deciding on (soft) worker restart

### DIFF
--- a/worker/workers/stable_diffusion.py
+++ b/worker/workers/stable_diffusion.py
@@ -112,7 +112,7 @@ class StableDiffusionWorker(WorkerFramework):
             gpu_info = GPUInfo()
             total_vram = gpu_info.get_total_vram_mb()
             loaded_model_ratio = total_vram / models_on_gpu
-            if loaded_model_ratio < 1500:
+            if total_vram and loaded_model_ratio < 1500:
                 # If 1500 MB per model is 'loaded', something is wrong as models have a bigger footprint than that
                 # and there would need to be room for inference, in any event.
                 logger.error("Detected more models in VRAM than should be possible.")


### PR DESCRIPTION
In Linux, gpu_info.get_total_vram_mb() can be 0.
If this happens, don't use this faulty measurement to decide to restart the worker.

This tweak allows me to enable lora's on Linux. Without it, the worker gets in a soft restart loop after generating a single lora, and then crashes.

Please note; I have tested this to run for a few hours without crashing, but it seems that using Lora's on linux is still leaking ram, so this is not a full fix. Up to you whether it's worth merging.