### PR TITLE
fix: prevent 'CLIPTokenizer' object has no attribute 'split_special_tokens' error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 torch # We have to place it here otherwise it installs the CPU version
 pydantic==1.10.12
 horde_model_reference~=0.2.2
+transformers==4.30.2
 hordelib==1.6.2
 gradio
 pyyaml

--- a/worker/jobs/scribe.py
+++ b/worker/jobs/scribe.py
@@ -70,7 +70,7 @@ class ScribeHordeJob(HordeJobFramework):
                     loop_retry += 1
                     time.sleep(3)
                     continue
-                if type(gen_req.json()) is not dict:
+                if not isinstance(gen_req.json(), dict):
                     logger.error(
                         (
                             f"KAI instance {self.bridge_data.kai_url} API unexpected response on generate: {gen_req}. "


### PR DESCRIPTION
This fixes the `AttributeError: 'CLIPTokenizer' object has no attribute 'split_special_tokens'` error that has cropped up with updated/new workers.

This is specifically for hordelib 1.6.2; transformers 4.30.2 is shown to not crash, where as 4.32.0 on seems to introduce a breaking change regarding the use of the aforementioned attribute causing an crash originating from within comfy.