### PR TITLE
fix: security issue with pillow+webp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu118
 torch # We have to place it here otherwise it installs the CPU version
+Pillow>=10.0.1
 pydantic==1.10.12
 horde_model_reference~=0.2.2
 transformers==4.30.2


### PR DESCRIPTION
All workers should `git pull` and `update-runtime` soon.

If you are a worker who does not want to do so, but wishes to apply the security fix, run the following in your `AI-Horde-Worker` folder:

```bash
runtime python -s -m pip install -U Pillow
```

See https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html for more information.