### PR TITLE
fix: do not attempt to load SDXL models

### DIFF
--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -135,6 +135,7 @@ models_to_load:
 # This is to avoid loading models which you do not want either due to VRAM constraints, or due to NSFW content
 models_to_skip:
   - "pix2pix"
+  - "SDXL 1.0" # Not supported in this worker.
   #- "stable_diffusion_inpainting"  # Inpainting is generally quite heavy along with other models for smaller GPUs.
   #- "stable_diffusion_2.1"  # Stable diffusion 2.1 has bigger memory requirements than 1.5, so if your card cannot lift, it, disable it
   #- "stable_diffusion_2.0"  # Same as Stable diffusion 2.1

--- a/worker/bridge_data/stable_diffusion.py
+++ b/worker/bridge_data/stable_diffusion.py
@@ -94,6 +94,13 @@ class StableDiffusionBridgeData(BridgeDataTemplate):
         if top_n:
             self.models_to_load.extend(self.get_top_n_models(top_n))
 
+        for i, model_name in enumerate(self.models_to_load):
+            if "SDXL" in model_name:
+                del self.models_to_load[i]
+                logger.error(
+                    f"SDXL models are not supported in this worker version. Removing {model_name}",
+                )
+
         if self.dynamic_models and not self.number_of_dynamic_models:
             logger.warning(
                 "Dynamic models are enabled but config option `number_of_dynamic_models` isn't set or is 0. "


### PR DESCRIPTION
Workers, particularly those who use meta modifiers, will get errors about failing to load SDXL models when options such as `all` are choosen. This sets the default to skip it for meta modifiers, and if it is specifically loaded an error will appear (and still be skipped).