### PR TITLE
Multi-threaded scribe

### DIFF
--- a/worker/bridge_data/scribe.py
+++ b/worker/bridge_data/scribe.py
@@ -32,8 +32,6 @@ class KoboldAIBridgeData(BridgeDataTemplate):
         super().reload_data()
         if hasattr(self, "scribe_name") and not self.args.worker_name:
             self.worker_name = self.scribe_name
-        # KAI doesn't support multiple threads
-        self.max_threads = 1
         if args.kai_url:
             self.kai_url = args.kai_url
         if args.sfw:

--- a/worker/jobs/poppers.py
+++ b/worker/jobs/poppers.py
@@ -218,6 +218,7 @@ class ScribePopper(JobPopper):
             "priority_usernames": self.bridge_data.priority_usernames,
             "softprompts": self.bridge_data.softprompts[self.bridge_data.model],
             "bridge_agent": self.BRIDGE_AGENT,
+            "threads": self.bridge_data.max_threads,
         }
 
     def horde_pop(self):


### PR DESCRIPTION
Various batching LLM backends with KAI support exist, making multithreaded scribe workers viable.
This patch removes the 1-thread restriction on scribes and reports thread count to horde.

Several workers are already using this modification to host multi-threaded workers on horde.