### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyyaml
 unidecode
 regex
 rembg
-pynvml
+pynvml == 11.5.0
 psutil
 windows-curses; sys_platform == 'win32'
 loguru


### PR DESCRIPTION
work around until pynvml 12 support
(from pynvml_utils import nvidia_smi )

11.5.2 or 11.5.3 would also work, but 11.5.0 seems more compatible.
