### PR TITLE
pynvml is deprecated

### DIFF
--- a/requirements-scribe.txt
+++ b/requirements-scribe.txt
@@ -2,7 +2,7 @@ gradio
 pyyaml
 unidecode
 regex
-pynvml
+nvidia-ml-py3
 psutil
 windows-curses; sys_platform == 'win32'
 loguru

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyyaml
 unidecode
 regex
 rembg
-pynvml
+nvidia-ml-py3
 psutil
 windows-curses; sys_platform == 'win32'
 loguru

--- a/worker/utils/gpuinfo.py
+++ b/worker/utils/gpuinfo.py
@@ -1,7 +1,7 @@
 import contextlib
 import os
 
-from pynvml.smi import nvidia_smi
+import nvidia_smi
 
 
 class GPUInfo:


### PR DESCRIPTION
See https://pypi.org/project/pynvml/ for more information.

Replaces with nvidia_smi library instead, as suggested in https://stackoverflow.com/questions/72238058/can-not-import-nvidia-smi

(Program will not start without those changes. Please squash before merging.)
(See also #325 to use an older version of pynvml instead)